### PR TITLE
Fix answer categorisation (correct vs incorrect) for the test

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,16 +44,19 @@ def evaluateTestQuestions():
             current_correct = total_correct
 
             if local_verbose:
-                print("") # Necessary newline due to line 71.
+                print("") # Necessary newline due to line 84.
                 print("Given answers vs actual answer:")
 
             if len(answer) > 1:
                 correct = True
                 for i in range(len(answer)):
-                    line[i + 2] = line[i + 2].strip()
-                    if local_verbose:
-                        print(answer[i].lower() + " vs " + line[i + 2].lower())
-                    if len(line) > i + 2 and answer[i].lower() != line[i + 2].lower():
+                    if len(line) > i + 2:
+                        line[i + 2] = line[i + 2].strip()
+                        if local_verbose:
+                            print(answer[i].lower() + " vs " + line[i + 2].lower())
+                        if answer[i].lower() != line[i + 2].lower():
+                            correct = False
+                    else:
                         correct = False
                 if correct:
                     total_correct += 1

--- a/main.py
+++ b/main.py
@@ -43,11 +43,16 @@ def evaluateTestQuestions():
             
             current_correct = total_correct
 
+            if local_verbose:
+                print("") # Necessary newline due to line 71.
+                print("Given answers vs actual answer:")
 
             if len(answer) > 1:
                 correct = True
                 for i in range(len(answer)):
                     line[i + 2] = line[i + 2].strip()
+                    if local_verbose:
+                        print(answer[i].lower() + " vs " + line[i + 2].lower())
                     if len(line) > i + 2 and answer[i].lower() != line[i + 2].lower():
                         correct = False
                 if correct:
@@ -57,16 +62,18 @@ def evaluateTestQuestions():
             elif len(answer) > 0:
                 answer = answer[0]
                 line[2] = line[2].strip()
+                if local_verbose:
+                    print(answer.lower() +  " vs " + line[2].lower())
                 if answer.lower() == line[2].lower():
                     total_correct += 1
                 else:
                     total_incorrect += 1
             else:
                 # No answer is available.
+                print("No answer was given.")
                 total_incorrect += 1
 
             if local_verbose:
-                print("") # Necessary newline due to line 71.
                 if current_correct == total_correct:
                     print("Incorrect: " + line[0])
                 else:

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def evaluateTestQuestions():
             
             current_correct = total_correct
 
-            if isinstance(answer, list):
+            if len(answer) > 1:
                 correct = True
                 for i in range(len(answer)):
                     if len(line) > i + 2 and answer[i].lower() != line[i + 2].lower():
@@ -52,14 +52,18 @@ def evaluateTestQuestions():
                     total_correct += 1
                 else:
                     total_incorrect += 1
-            else:
+            elif len(answer) > 0:
+                answer = answer[0]
                 if answer.lower() == line[2].lower():
                     total_correct += 1
                 else:
                     total_incorrect += 1
+            else:
+                # No answer is available.
+                total_incorrect += 1
 
             if local_verbose:
-                print("") # Necessary newline due to line 61.
+                print("") # Necessary newline due to line 71.
                 if current_correct == total_correct:
                     print("Incorrect: " + line[0])
                 else:

--- a/main.py
+++ b/main.py
@@ -43,9 +43,11 @@ def evaluateTestQuestions():
             
             current_correct = total_correct
 
+
             if len(answer) > 1:
                 correct = True
                 for i in range(len(answer)):
+                    line[i + 2] = line[i + 2].strip()
                     if len(line) > i + 2 and answer[i].lower() != line[i + 2].lower():
                         correct = False
                 if correct:
@@ -54,6 +56,7 @@ def evaluateTestQuestions():
                     total_incorrect += 1
             elif len(answer) > 0:
                 answer = answer[0]
+                line[2] = line[2].strip()
                 if answer.lower() == line[2].lower():
                     total_correct += 1
                 else:


### PR DESCRIPTION
It's not the main feature of this PR, but I also added some more verbosity. This is because the submitted answers should be taken with a grain of salt. The reason for this is because they did not submit the exact answers (that a machine would give) but often have a certain way of denoting the date, extra remarks (e.g. "(english)" behind a name), or lists not in the order given by the api. So now you can easily see if the difference between the system's answer and the submitted is within satisfactory boundaries or not.